### PR TITLE
fix restore saved state

### DIFF
--- a/lib/src/main/java/com/claudiodegio/msv/BaseMaterialSearchView.java
+++ b/lib/src/main/java/com/claudiodegio/msv/BaseMaterialSearchView.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
+import android.os.Parcel;
 import android.os.Parcelable;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -299,11 +300,33 @@ public abstract class BaseMaterialSearchView extends FrameLayout implements View
         return savedState;
     }
 
-    class BaseMSVSavedState extends BaseSavedState {
+    static class BaseMSVSavedState extends BaseSavedState {
         public boolean isOpen;
 
         public BaseMSVSavedState(Parcelable superState) {
             super(superState);
+        }
+
+        @Override
+        public void writeToParcel(Parcel out, int flags) {
+            super.writeToParcel(out, flags);
+            out.writeByte(isOpen ? (byte) 1 : (byte) 0);
+        }
+
+        public static final Parcelable.Creator<BaseMSVSavedState> CREATOR =
+                new Parcelable.Creator<BaseMSVSavedState>() {
+                    public BaseMSVSavedState createFromParcel(Parcel in) {
+                        return new BaseMSVSavedState(in);
+                    }
+
+                    public BaseMSVSavedState[] newArray(int size) {
+                        return new BaseMSVSavedState[size];
+                    }
+                };
+
+        public BaseMSVSavedState(Parcel in) {
+            super(in);
+            isOpen = in.readByte() == 1;
         }
     }
 


### PR DESCRIPTION
Fix implementation of BaseMSVSavedState. 
onRestoreInstance produce exception, my changes make save and restore instance correct.

`                     java.lang.RuntimeException: Unable to start activity ComponentInfo{}: java.lang.IllegalArgumentException: Wrong state class, expecting View State but received class android.view.View$BaseSavedState instead. This usually happens when two views of different type have the same id in the same hierarchy. This view's id is id/search_view_bar. Make sure other views do not use the same id.
                                         at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2521)
                                         at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2595)
                                         at android.app.ActivityThread.access$800(ActivityThread.java:178)
                                         at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1470)
                                         at android.os.Handler.dispatchMessage(Handler.java:111)
                                         at android.os.Looper.loop(Looper.java:194)
                                         at android.app.ActivityThread.main(ActivityThread.java:5631)
                                         at java.lang.reflect.Method.invoke(Native Method)
                                         at java.lang.reflect.Method.invoke(Method.java:372)
                                         at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:959)
                                         at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:754)`